### PR TITLE
Swap sass compiler

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -223,7 +223,7 @@ bpwatch start post_compile
   source $BIN_DIR/steps/hooks/post_compile
 bpwatch stop post_compile
 
-# Django collectstatic support.
+# Django collectstatic support + sass compiling before.
 sub-env $BIN_DIR/steps/collectstatic
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -192,7 +192,10 @@ source $BIN_DIR/steps/gdal
 # Install dependencies with Pip.
 source $BIN_DIR/steps/pip-install
 
-# SASS support.
+# # Install NodeJS.
+source $BIN_DIR/steps/node
+
+# # SASS support.
 source $BIN_DIR/steps/sass
 
 # Gettext support.
@@ -222,6 +225,10 @@ bpwatch stop post_compile
 
 # Django collectstatic support.
 sub-env $BIN_DIR/steps/collectstatic
+
+
+# # Uninstall NodeJS. (Be sure to compile react before this)
+source $BIN_DIR/steps/removenode
 
 
 # Store new artifacts in cache.

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -14,17 +14,9 @@ function compile_gettext {
     make PYTHON_EXE=$PYTHON_EXE compilemessages
 }
 
-function compile_sass {
-    # Sass
-    export PATH=$HOME/.gem/bin:$PATH
-    puts-step "Compiling sass"
-    make PYTHON_EXE=$PYTHON_EXE sass
-}
-
 # Execute steps
 puts-step "Using python $PYTHON_EXE"
 compile_gettext
-compile_sass
 
 # Apply migrations
 if [ "$MIGRATE_ON_DEPLOY" = "1" ]; then

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -9,6 +9,9 @@ MANAGE_FILE=${MANAGE_FILE:-fakepath}
 
 bpwatch start collectstatic
 
+
+# Added since 19/03/2019 with dart-sass
+puts-step "Compiling sass"
 make sass
 
 if [ $DISABLE_COLLECTSTATIC -eq 0 ] && [ -f "$MANAGE_FILE" ]; then

--- a/bin/steps/collectstatic
+++ b/bin/steps/collectstatic
@@ -9,6 +9,8 @@ MANAGE_FILE=${MANAGE_FILE:-fakepath}
 
 bpwatch start collectstatic
 
+make sass
+
 if [ $DISABLE_COLLECTSTATIC -eq 0 ] && [ -f "$MANAGE_FILE" ]; then
     set +e
 

--- a/bin/steps/node
+++ b/bin/steps/node
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+bpwatch start nodejs
+
+VERSION=10.15.3
+
+# Get NVM
+export NVM_DIR="$HOME/.nvm" && (
+  git clone https://github.com/creationix/nvm.git "$NVM_DIR"
+  cd "$NVM_DIR"
+  git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
+) && \. "$NVM_DIR/nvm.sh"
+
+echo "Installing Node.js ($VERSION)…"
+nvm install $VERSION
+
+bpwatch stop nodejs

--- a/bin/steps/removenode
+++ b/bin/steps/removenode
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+bpwatch start removenodejs
+
+rm -rf .nvm
+
+bpwatch stop removenodejs

--- a/bin/steps/sass
+++ b/bin/steps/sass
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
 
-GEM_DIR=$HOME/.gem/
-
 bpwatch start sass
-
 puts-step "Installing SASS..."
-if [ ! -d "$GEM_DIR" ]; then
-  mkdir $GEM_DIR
-fi
-gem install sass -v 3.4 --no-rdoc --no-ri --install-dir "$GEM_DIR" | indent
-export GEM_PATH=$GEM_PATH:$GEM_DIR
-puts-step "Done in $GEM_PATH"
+
+npm install -g sass
 
 bpwatch stop sass


### PR DESCRIPTION
Remove ruby / ruby sass
Now use Dart-Sass installed by node.js (that prepare for react) who are removed before the end of "compile" steps
Move sass building before collectstatic

[Associated website PR](https://github.com/CBien/cbien-website/pull/1563)